### PR TITLE
Redefine Library Paths didn't work

### DIFF
--- a/wardrobe.py
+++ b/wardrobe.py
@@ -585,7 +585,7 @@ class HISANIM_OT_relocatePaths(bpy.types.Operator):
 
     def execute(self, context):
         prefs = context.preferences.addons[__package__].preferences
-        paths = prefs.assets
+        paths = prefs.hisanim_paths
         files = list(map(lambda a: a +'cosmetics.blend', mercdeployer.mercs)) + ['allclass.blend', 'allclass2.blend', 'allclass3.blend']
         filesDict = {key: key.replace('cosmetics', '').replace('.blend', '') for key in files}
         TF2_V3 = list(map(lambda a: a + '.blend', mercdeployer.mercs))


### PR DESCRIPTION
Changing this, has (for me) made the Redefine Library Paths button work

I'm not very familiar with blender add-ons, let alone this one, this has made the redefine button work for me again, might wanna check.